### PR TITLE
Update plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -49,7 +49,7 @@
             <access origin="https://api.facebook.com" />
             <access origin="https://*.fbcdn.net" />
             <access origin="https://*.akamaihd.net" />
-            <preference name="android-minSdkVersion" value="15" />
+            <preference name="android-minSdkVersion" value="16" />
         </config-file>
 
         <source-file src="src/android/facebookconnect.xml" target-dir="res/values" />


### PR DESCRIPTION
Having android-minSdkVersion at 15 was causing a build problem in projects with the latest version of cordova-plugin-fcm-with-dependecy-updated (currently 7.8.0).  Updating it to 16 fixes this build problem.  Incidentally, it also fixes a visual issue where the app doesn't respect the spacing of the top notches on certain ios devices.  Updating to 16 also fixes this issue, though I can't explain why.